### PR TITLE
Remove the need for the pyalsaaudio library

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,6 +1,5 @@
 import pygame
 import random
-import alsaaudio
 import torch
 from neural_network import AdvancedReinforcementLearning
 
@@ -10,15 +9,6 @@ try:
 except pygame.error as e:
     print(f"Error initializing Pygame: {e}")
     exit()
-
-def check_alsa_errors():
-    try:
-        alsaaudio.cards()
-    except alsaaudio.ALSAAudioError as e:
-        print(f"ALSA error: {e}")
-    exit()
-
-check_alsa_errors()
 
 # Screen dimensions
 SCREEN_WIDTH = 800

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pygame
 torch
 numpy
-pyalsaaudio

--- a/train.py
+++ b/train.py
@@ -2,15 +2,8 @@ import torch
 import torch.optim as optim
 import numpy as np
 import pygame
-import alsaaudio
 from game import Paddle, Ball
 from neural_network import AdvancedReinforcementLearning
-
-def check_alsa_errors():
-    try:
-        alsaaudio.cards()
-    except alsaaudio.ALSAAudioError as e:
-        print(f"ALSA error: {e}")
 
 # Hyperparameters
 input_size = 4
@@ -38,8 +31,6 @@ try:
 except pygame.error as e:
     print(f"Error initializing game objects: {e}")
     exit()
-
-check_alsa_errors()
 
 # Hyperparameter tuning
 learning_rates = [0.001, 0.01, 0.1]


### PR DESCRIPTION
Remove the dependency on the `pyalsaaudio` library.

* **game.py**
  - Remove the import statement for `alsaaudio`.
  - Remove the `check_alsa_errors` function and its call.

* **train.py**
  - Remove the import statement for `alsaaudio`.
  - Remove the `check_alsa_errors` function and its call.

* **requirements.txt**
  - Remove the `pyalsaaudio` dependency.

