### PR TITLE
Fix syntax error in neural_network.py

### DIFF
--- a/neural_network.py
+++ b/neural_network.py
@@ -100,7 +100,7 @@ class ReinforcementLearning:
         best_params = None
         best_performance = float('-inf')
 
-        for lr in learning rates:
+        for lr in learning_rates:
             for hs in hidden_sizes:
                 for bs in batch_sizes:
                     performance = self.evaluate_model(lr, hs, bs)


### PR DESCRIPTION
Fix a syntax error in the `hyperparameter_tuning` method in `neural_network.py`.

* Change `learning rates` to `learning_rates` in the for loop to correct the syntax error.
