### PR TITLE
Add audio device check and fallback mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,38 @@ The code has been updated to include error handling for various parts of the gam
    python train.py
    ```
 3. The trained models will be saved in the `models` directory.
+
+## Audio Device Requirement
+
+The game requires an audio device for sound effects and background music. If no audio device is available, the game will disable sound.
+
+### Disabling Sound
+
+If you do not have an audio device or if you encounter issues with sound, you can disable sound by modifying the `game.py` file. Locate the following section in the code:
+
+```python
+# Check for audio device
+audio_device_available = True
+try:
+    pygame.mixer.init()
+except pygame.error as e:
+    print(f"Error initializing sound: {e}")
+    audio_device_available = False
+
+# Sound effects and background music
+if audio_device_available:
+    try:
+        hit_sound = pygame.mixer.Sound("hit.wav")
+        score_sound = pygame.mixer.Sound("score.wav")
+        pygame.mixer.music.load("background_music.mp3")
+        pygame.mixer.music.play(-1)
+    except pygame.error as e:
+        print(f"Error loading sound files: {e}")
+        audio_device_available = False
+```
+
+You can disable sound by setting `audio_device_available` to `False`:
+
+```python
+audio_device_available = False
+```

--- a/game.py
+++ b/game.py
@@ -33,16 +33,24 @@ except pygame.error as e:
     print(f"Error creating screen: {e}")
     exit()
 
-# Sound effects and background music
+# Check for audio device
+audio_device_available = True
 try:
     pygame.mixer.init()
-    hit_sound = pygame.mixer.Sound("hit.wav")
-    score_sound = pygame.mixer.Sound("score.wav")
-    pygame.mixer.music.load("background_music.mp3")
-    pygame.mixer.music.play(-1)
 except pygame.error as e:
     print(f"Error initializing sound: {e}")
-    exit()
+    audio_device_available = False
+
+# Sound effects and background music
+if audio_device_available:
+    try:
+        hit_sound = pygame.mixer.Sound("hit.wav")
+        score_sound = pygame.mixer.Sound("score.wav")
+        pygame.mixer.music.load("background_music.mp3")
+        pygame.mixer.music.play(-1)
+    except pygame.error as e:
+        print(f"Error loading sound files: {e}")
+        audio_device_available = False
 
 # Paddle class
 class Paddle(pygame.sprite.Sprite):
@@ -125,12 +133,14 @@ class Ball(pygame.sprite.Sprite):
             self.reset_position()
             global player2_score
             player2_score += 1
-            score_sound.play()
+            if audio_device_available:
+                score_sound.play()
         elif self.rect.x >= SCREEN_WIDTH - BALL_SIZE:
             self.reset_position()
             global player1_score
             player1_score += 1
-            score_sound.play()
+            if audio_device_available:
+                score_sound.play()
 
         self.apply_friction()
         self.apply_gravity()
@@ -165,7 +175,8 @@ class Ball(pygame.sprite.Sprite):
         if self.rect.colliderect(paddle.get_bounding_box()):
             offset = (paddle.rect.x - self.rect.x, paddle.rect.y - self.rect.y)
             if paddle.get_mask().overlap(self.get_mask(), offset):
-                hit_sound.play()
+                if audio_device_available:
+                    hit_sound.play()
                 return True
         return False
 


### PR DESCRIPTION
Add a check for the presence of an audio device before initializing `pygame.mixer` and a fallback mechanism to disable sound if no audio device is found.

* **game.py**
  - Add a check for audio device availability before initializing `pygame.mixer`.
  - Add a fallback mechanism to disable sound if no audio device is found.
  - Modify sound effect and background music initialization to check for audio device availability.
  - Add conditional checks before playing sound effects to ensure an audio device is available.

* **README.md**
  - Add a note about the requirement of an audio device for sound effects and background music.
  - Add instructions on how to disable sound if no audio device is available.

