### PR TITLE
Fix missing speed_x and speed_y attributes in Ball class

### DIFF
--- a/game.py
+++ b/game.py
@@ -110,6 +110,8 @@ class Ball(pygame.sprite.Sprite):
         self.rally_duration = 0
         self.gravity = 0.1
         self.air_resistance = 0.99
+        self.speed_x = 0  # P470d
+        self.speed_y = 0  # P470d
 
     def set_ball_properties(self):
         if self.ball_type == "normal":

--- a/train.py
+++ b/train.py
@@ -6,7 +6,7 @@ from game import Paddle, Ball
 from neural_network import AdvancedReinforcementLearning
 
 # Hyperparameters
-input_size = 4
+input_size = 3
 hidden_size = 256
 output_size = 1
 learning_rate = 0.01


### PR DESCRIPTION
Add `speed_x` and `speed_y` attributes to the `Ball` class and update `input_size` in `train.py`.

* **game.py**
  - Initialize `speed_x` and `speed_y` attributes in the `Ball` class constructor.
* **train.py**
  - Update `input_size` to 3 to match the state size used in `game.py`.

